### PR TITLE
Use ARG instead of ENV and use 6.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN update-rc.d mysql defaults
 
 # ------------------------------------------------------------------------------
 # Install Pydio
-ENV PYDIO_VERSION 6.2.0
+ARG PYDIO_VERSION=6.2.2
 WORKDIR /var/www
 RUN wget http://downloads.sourceforge.net/project/ajaxplorer/pydio/stable-channel/${PYDIO_VERSION}/pydio-core-${PYDIO_VERSION}.zip
 RUN unzip pydio-core-${PYDIO_VERSION}.zip


### PR DESCRIPTION
This allows users to build a new version on their own with: ``docker build --build-arg PYDIO_VERSION=6.2.2 -t kdelfour/pydio-docker .``